### PR TITLE
Obmin 327 on the add advertisement page, the headline field has a duplicate validation, and the exchange field validation has a large margin from the field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@Wolshebnik/obminyashka-components",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@Wolshebnik/obminyashka-components",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "license": "ISC",
       "dependencies": {
         "formik": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@Wolshebnik/obminyashka-components",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "description": "Component library",
   "main": "dist/esm/index.js",
   "module": "dist/cjs/index.js",

--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -6,13 +6,20 @@ export const CheckBox = ({
   gap,
   name,
   text,
+  style,
   fontSize,
   onChange,
   checked = false,
   type = 'checkbox',
   ...props
 }: IInput) => (
-  <Styles.Label gap={gap} type={type} checked={checked} fontSize={fontSize}>
+  <Styles.Label
+    gap={gap}
+    type={type}
+    style={style}
+    checked={checked}
+    fontSize={fontSize}
+  >
     <Styles.Input
       name={name}
       type={type}

--- a/src/components/input/Input.stories.tsx
+++ b/src/components/input/Input.stories.tsx
@@ -64,8 +64,10 @@ Error.args = {
   type: 'text',
   inputGap: '',
   error: 'Error',
+  errorGap: '5px',
   name: 'inputName',
   label: 'Label text',
+  errorFontSize: '16px',
   inputFlexDirection: '',
   placeholder: 'Placeholder',
 };

--- a/src/components/input/arg-types.ts
+++ b/src/components/input/arg-types.ts
@@ -34,12 +34,24 @@ export const argTypes = {
     control: { type: 'text' },
   },
 
+  errorGap: {
+    name: 'errorGap',
+    type: { name: 'string' },
+    description:
+      'CSS property, sets the gap between error message and input.\n\n ' +
+      '\n\nExamples : "20px"(em,rem) or "10px 5px"(em,rem)',
+    table: {
+      type: { summary: 'string' },
+    },
+    control: { type: 'text' },
+  },
+
   type: {
     name: 'Type',
     type: { name: 'string' },
     description:
-      'HTML attribute. This component handles three types of this ' +
-      'attribute ("text", "password", "tel").\n\n"text" - you can enter' +
+      'HTML attribute. This component handles several types of this ' +
+      'attribute ("text", "password", "tel", "search").\n\n"text" - you can enter' +
       ' all characters, letters and numbers, the content of the input is ' +
       'visible and not validated. \n\n"password" - hides the entered data, ' +
       'replacing them with `****`. It also adds an icon to the right that' +
@@ -118,6 +130,15 @@ export const argTypes = {
     name: 'LabelFontSize',
     type: { name: 'string' },
     description: `CSS property.\n\n Sets size text of label.\n\nWritten in a
+      string type to define units of measure. Example : "10px (rem,em)"`,
+    table: {
+      type: { summary: 'string' },
+    },
+  },
+  errorFontSize: {
+    name: 'ErrorFontSize',
+    type: { name: 'string' },
+    description: `CSS property.\n\n Sets size text of error.\n\nWritten in a
       string type to define units of measure. Example : "10px (rem,em)"`,
     table: {
       type: { summary: 'string' },

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -13,8 +13,10 @@ const Input = ({
   error,
   onClick,
   inputGap,
+  errorGap,
   labelColor,
   placeholder,
+  errorFontSize,
   labelFontSize,
   inputMaxWidth,
   labelFontWeight,
@@ -59,6 +61,7 @@ const Input = ({
       )}
 
       <Styles.WrapperInputError
+        errorGap={errorGap}
         isTypeSearch={isTypeSearch}
         wrapperInputErrorWidth={wrapperInputErrorWidth}
       >
@@ -104,7 +107,11 @@ const Input = ({
           {!notPasswordType && component}
         </Styles.InputIcon>
 
-        {error && <Styles.SpanError error={error}>{error}</Styles.SpanError>}
+        {error && (
+          <Styles.SpanError error={error} errorFontSize={errorFontSize}>
+            {error}
+          </Styles.SpanError>
+        )}
       </Styles.WrapperInputError>
     </Styles.Label>
   );

--- a/src/components/input/styles.ts
+++ b/src/components/input/styles.ts
@@ -1,6 +1,12 @@
 import styled, { css } from 'styled-components';
 
-import { IInput, ILabel, ILabelSpan, IWrapperInputError } from './types';
+import {
+  IInput,
+  ILabel,
+  ILabelSpan,
+  ISpanError,
+  IWrapperInputError,
+} from './types';
 
 export const Label = styled.label<ILabel>`
   display: flex;
@@ -108,7 +114,8 @@ export const WrapperInputError = styled.div<IWrapperInputError>`
   display: flex;
   flex-direction: column;
 
-  ${({ wrapperInputErrorWidth, isTypeSearch }) => css`
+  ${({ wrapperInputErrorWidth, isTypeSearch, errorGap }) => css`
+    ${errorGap && `gap:${errorGap};`}
     ${wrapperInputErrorWidth && `width: ${wrapperInputErrorWidth}`};
     ${isTypeSearch &&
     css`
@@ -175,13 +182,13 @@ export const WrapperReset = styled.div`
   }
 `;
 
-export const SpanError = styled.span<{ error: string }>`
-  font-size: 12px;
+export const SpanError = styled.span<ISpanError>`
   font-style: normal;
   font-weight: 400;
   line-height: 20px;
 
-  ${({ theme, error }) => css`
+  ${({ theme, error, errorFontSize }) => css`
+    font-size: ${errorFontSize || '12px'};
     color: ${theme.colors.input.error};
 
     ${Input} {

--- a/src/components/input/types.ts
+++ b/src/components/input/types.ts
@@ -22,8 +22,10 @@ export interface InputProps extends Omit<CustomInput, 'ref'> {
   error?: string;
   label?: string;
   inputGap?: string;
+  errorGap?: string;
   labelColor?: string;
   labelFontSize?: string;
+  errorFontSize?: string;
   inputMaxWidth?: string;
   labelFontWeight?: number;
   inputFlexDirection?: string;
@@ -47,6 +49,7 @@ export interface ILabelSpan extends Pick<ILabel, 'inputFlexDirection'> {
 }
 
 export interface IWrapperInputError extends Pick<ILabel, 'isTypeSearch'> {
+  errorGap?: string;
   wrapperInputErrorWidth?: string;
 }
 
@@ -55,3 +58,6 @@ export interface IInput extends Pick<ILabel, 'isTypeSearch'> {
   autoComplete?: string;
   notPasswordType: boolean;
 }
+
+export interface ISpanError
+  extends Pick<InputProps, 'error' | 'errorFontSize'> {}


### PR DESCRIPTION
- added props into Input: errorFontSize, errorGap.
- added props into CheckBox: style. Threw them into the label